### PR TITLE
Fix calculation of receiver id

### DIFF
--- a/sepicker/elster/elster.py
+++ b/sepicker/elster/elster.py
@@ -18,7 +18,7 @@ class Elster:
     def listener(self, msg):
         data = msg.data
 
-        receiver = (data[0] & 0xf0) * 8 + (data[1] & 0x0f)
+        receiver = (data[0] & 0xf0) * 8 + (data[1] & 0x7f)
         type = data[0] & 0x0f
 
         if type != self.RESPONSE or \


### PR DESCRIPTION
I used 79f as sender id, but the received frames were dropped during the check in Elster.listener. The reason was the incorrect calculation of the receiver id. This is fixed by this pull request.

I've used KCanFrame::GetReceiverId() in NCanUtils.cpp as reference.